### PR TITLE
Bugfix - add missing ignore error statements

### DIFF
--- a/modules/assembly.nf
+++ b/modules/assembly.nf
@@ -2,6 +2,8 @@ process ASSEMBLY_SHOVILL {
     label 'shovill_container'
     label 'farm_high_fallible'
 
+    errorStrategy 'ignore'
+
     tag "$sample_id"
 
     input:

--- a/modules/curate_cps_sequence.nf
+++ b/modules/curate_cps_sequence.nf
@@ -5,6 +5,8 @@ process CURATE_CPS_SEQUENCE {
     label 'cps_extractor_python_container'
     label 'farm_low_fallible'
 
+    errorStrategy 'ignore'
+
     tag "$sample_id"
 
     input:


### PR DESCRIPTION
Minor bugfix as errors are currently only ignored in the LSF profile for assembly and cps curation.