### PR TITLE
Improve error handling

### DIFF
--- a/bin/check_cps_sequence.py
+++ b/bin/check_cps_sequence.py
@@ -1,11 +1,27 @@
 #!/usr/bin/env python3
 
+import logging
+
 from lib.annotation import Annotation
 from lib.argparser import AnnotationParser
+
+logging.basicConfig(
+    filename=f"cps_extractor.log",
+    encoding="utf-8",
+    level=logging.ERROR,
+)
 
 
 def main(args):
     Annotator = Annotation(args.cps_sequence, args.bakta_input)
+
+    cps_seq_length = Annotator.check_seq_length()
+    # basic sanity check to make sure there is a genuine blast hit to the reference DB
+    if cps_seq_length < 8000:
+        logging.error(
+            f"The CPS sequence length is unusually low ({cps_seq_length} bases), please check the blast results file you may have a non capsulated sample or a pneumo 'like' sample"
+        )
+        raise SystemExit(1)
 
     sample_name = args.cps_sequence.split(".fa")[0]
     cds_gff = Annotator.get_cds_annotations(

--- a/lib/annotation.py
+++ b/lib/annotation.py
@@ -13,6 +13,12 @@ class Annotation:
         self.bakta_outdir = bakta_outdir
         self.reference_basename = self.cps_fasta.split(".fa")[0]
 
+    def check_seq_length(self) -> int:
+        # basic check to see if the CPS sequence length is at least 10000 bases
+        sequence = SeqIO.parse(self.cps_fasta, "fasta")
+        for record in sequence:
+            return len(record.seq)
+
     def check_sequence_completeness(
         self, sequence: str, sequence_id: str
     ) -> (bool, str):

--- a/lib/blastn.py
+++ b/lib/blastn.py
@@ -77,7 +77,7 @@ class Blast:
         # basic check to see if there are any blast hits before running the code
         if len(final_blast_results) == 0:
             logging.error(
-                "The blast results file is empty, please check your blast database and input sequence"
+                "The blast results contain no hits, please check your blast database and input sequence. Your input sequence may be a non encapsulated strain."
             )
             raise SystemExit(1)
 

--- a/modules/check_cps_sequence.nf
+++ b/modules/check_cps_sequence.nf
@@ -5,10 +5,13 @@ process CHECK_CPS_SEQUENCE {
     label 'cps_extractor_python_container'
     label 'farm_low'
 
+    errorStrategy 'ignore'
+
     tag "$sample_id"
 
     input:
     tuple val(sample_id), path(bakta_results), path(cps_sequence), val(reference)
+    val(results_dir)
 
     output:
     tuple val(sample_id), path(annotation_file), path(mutation_file), val(reference), emit: results_ch
@@ -17,6 +20,7 @@ process CHECK_CPS_SEQUENCE {
     annotation_file="${bakta_results}/${sample_id}_cps.gff3"
     mutation_file="${sample_id}_cps_mutations.csv"
     """
-    check_cps_sequence.py -c ${cps_sequence} -b ${bakta_results}
+    # catch the sanity check for sequence length and append the error message to the log file
+    check_cps_sequence.py -c ${cps_sequence} -b ${bakta_results} || { cat cps_extractor.log >> ${results_dir}/${sample_id}/cps_extractor.log; exit 1; }
     """
 }

--- a/modules/check_cps_sequence.nf
+++ b/modules/check_cps_sequence.nf
@@ -3,7 +3,7 @@ process CHECK_CPS_SEQUENCE {
     publishDir "${params.output}/${sample_id}", mode: 'copy', overwrite: true, pattern: "*.{csv,gff3}"
 
     label 'cps_extractor_python_container'
-    label 'farm_low'
+    label 'farm_low_fallible'
 
     errorStrategy 'ignore'
 

--- a/modules/curate_cps_sequence.nf
+++ b/modules/curate_cps_sequence.nf
@@ -11,6 +11,7 @@ process CURATE_CPS_SEQUENCE {
 
     input:
     tuple val(sample_id), path(assembly), path(blast_results), val(serotype), path(reads)
+    val (results_dir)
 
     output:
     tuple val(sample_id), path(cps_sequence), path(reads), val(serotype), emit: cps_sequence_ch
@@ -30,10 +31,10 @@ process CURATE_CPS_SEQUENCE {
         if ! curate_cps_sequence.py -b ${blast_results} -o ${sample_id}_cps.fa -s \${sero_final}
         then
           echo "No cps sequence found for \${sero_final}, running without specifying the serotype, please check the log file for more information."
-          curate_cps_sequence.py -b ${blast_results} -o ${sample_id}_cps.fa
+          curate_cps_sequence.py -b ${blast_results} -o ${sample_id}_cps.fa || { cp cps_extractor.log ${results_dir}/${sample_id}; exit 1; }
         fi
     else
-        curate_cps_sequence.py -b ${blast_results} -o ${sample_id}_cps.fa
+        curate_cps_sequence.py -b ${blast_results} -o ${sample_id}_cps.fa || { cp cps_extractor.log ${results_dir}/${sample_id}; exit 1; }
     fi
     """
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -114,7 +114,7 @@ profiles {
             withLabel: farm_low_fallible {
                 cpus = 1
                 memory = {1.GB * task.attempt}
-                errorStrategy = { task.exitStatus == 1 ? 'ignore' : params.maxretries <= params.maxretries ? 'retry' : 'ignore' }
+                errorStrategy = { task.exitStatus == 1 ? 'ignore' : task.attempt <= params.maxretries ? 'retry' : 'ignore' }
                 maxRetries = params.maxretries
             }
             withLabel: farm_mid {

--- a/nextflow.config
+++ b/nextflow.config
@@ -114,7 +114,7 @@ profiles {
             withLabel: farm_low_fallible {
                 cpus = 1
                 memory = {1.GB * task.attempt}
-                errorStrategy = { task.attempt <= params.maxretries ? 'retry' : 'ignore' }
+                errorStrategy = { task.exitStatus == 1 ? 'ignore' : params.maxretries <= params.maxretries ? 'retry' : 'ignore' }
                 maxRetries = params.maxretries
             }
             withLabel: farm_mid {

--- a/nextflow.config
+++ b/nextflow.config
@@ -33,7 +33,7 @@ env {
 // Set process container images
 process {
     withLabel: bakta_container {
-        container = 'quay.io/biocontainers/bakta:1.9.2--pyhdfd78af_0'
+        container = 'quay.io/biocontainers/bakta:1.9.3--pyhdfd78af_0'
     }
     withLabel: bash_container {
         container = 'wbitt/network-multitool:69aa4d5'

--- a/tests/test_annotation.py
+++ b/tests/test_annotation.py
@@ -7,8 +7,12 @@ from lib.annotation import Annotation
 
 @pytest.fixture
 def annotator():
-    annotator = Annotation("tests/test_data/test_cps.fa", "tests/test_data")
+    annotator = Annotation("tests/test_data/cps_seq.fa", "tests/test_data")
     return annotator
+
+
+def test_check_seq_length(annotator):
+    assert annotator.check_seq_length() == 14936
 
 
 def test_check_sequence_completeness_no_mutations(annotator):

--- a/tests/test_blastn.py
+++ b/tests/test_blastn.py
@@ -145,7 +145,7 @@ def test_get_best_hit_empty_blast_result(blast, caplog):
         with caplog.at_level(logging.ERROR):
             blast.get_best_hit(empty_blast_results, serotype)
     assert (
-        "The blast results file is empty, please check your blast database and input sequence"
+        "The blast results contain no hits, please check your blast database and input sequence. Your input sequence may be a non encapsulated strain."
         in caplog.text
     )
     assert exit_info.value.code == 1

--- a/workflows/pipeline.nf
+++ b/workflows/pipeline.nf
@@ -15,6 +15,8 @@ workflow PIPELINE {
         blast_db = file( "${params.blastdb}.n*" )
         blast_db_ch = Channel.fromPath( blast_db )
 
+        results_dir_ch = Channel.fromPath( params.output )
+
         prodigal_training_file = Channel.fromPath( params.prodigal_training_file )
 
         bakta_db = Channel.fromPath( params.bakta_db )
@@ -34,13 +36,13 @@ workflow PIPELINE {
 
         BLASTN( assembly_ch, blast_db_ch.first() )
 
-        CURATE_CPS_SEQUENCE( BLASTN.out.blast_results_ch )
+        CURATE_CPS_SEQUENCE( BLASTN.out.blast_results_ch, results_dir_ch.first() )
 
         GAP_FILLER( CURATE_CPS_SEQUENCE.out.cps_sequence_ch, CURATE_CPS_SEQUENCE.out.log_ch, reference_db_ch.first() )
 
         BAKTA( GAP_FILLER.out.gap_filled_ch, prodigal_training_file.first(), bakta_db.first() )
 
-        CHECK_CPS_SEQUENCE( BAKTA.out.bakta_results_ch )
+        CHECK_CPS_SEQUENCE( BAKTA.out.bakta_results_ch, results_dir_ch.first() )
 
         CHECK_GENE_ORDER( CHECK_CPS_SEQUENCE.out.results_ch, reference_db_ch.first() )
 


### PR DESCRIPTION
Small changes to ensure that log files are always published to the results folder, even when processes fail. This allows users to more easily assess what went wrong in failed samples.