### PR TITLE
improve annotations

### DIFF
--- a/modules/bakta.nf
+++ b/modules/bakta.nf
@@ -10,6 +10,7 @@ process BAKTA {
     tuple val(sample_id), path(cps_sequence), val(reference)
     path(prodigal_training_file)
     path(bakta_db)
+    path(reference_database)
 
     output:
     tuple val(sample_id), path(bakta_results), path(cps_sequence), val(reference), emit: bakta_results_ch
@@ -17,6 +18,6 @@ process BAKTA {
     script:
     bakta_results="${sample_id}_bakta"
     """
-    bakta --db ${bakta_db} -t ${params.bakta_threads} -o ${sample_id}_bakta --prodigal-tf ${prodigal_training_file} --skip-plot ${cps_sequence}
+    bakta --db ${bakta_db} -t ${params.bakta_threads} -o ${sample_id}_bakta --prodigal-tf ${prodigal_training_file} --proteins ${reference_database}/proteins/${reference}_proteins.txt --skip-plot ${cps_sequence}
     """
 }

--- a/modules/check_cps_sequence.nf
+++ b/modules/check_cps_sequence.nf
@@ -1,6 +1,7 @@
 // Check CPS sequence for disruptive mutations
 process CHECK_CPS_SEQUENCE {
-    publishDir "${params.output}/${sample_id}", mode: 'copy', overwrite: true, pattern: "*.{csv,gff3}"
+    publishDir "${params.output}/${sample_id}", mode: 'copy', overwrite: true, pattern: "*.csv"
+    publishDir "${params.output}/${sample_id}", mode: 'copy', overwrite: true, pattern: "**_cps.gff3", saveAs: { fn -> fn.substring(fn.lastIndexOf('/')+1) }
 
     label 'cps_extractor_python_container'
     label 'farm_low_fallible'

--- a/workflows/pipeline.nf
+++ b/workflows/pipeline.nf
@@ -40,7 +40,7 @@ workflow PIPELINE {
 
         GAP_FILLER( CURATE_CPS_SEQUENCE.out.cps_sequence_ch, CURATE_CPS_SEQUENCE.out.log_ch, reference_db_ch.first() )
 
-        BAKTA( GAP_FILLER.out.gap_filled_ch, prodigal_training_file.first(), bakta_db.first() )
+        BAKTA( GAP_FILLER.out.gap_filled_ch, prodigal_training_file.first(), bakta_db.first(), reference_db_ch.first() )
 
         CHECK_CPS_SEQUENCE( BAKTA.out.bakta_results_ch, results_dir_ch.first() )
 


### PR DESCRIPTION
Improve the quality of annotations by using the `--proteins` option in bakta. This improves naming conventions - e.g. instead of cps4A, the gene will be named as wzg 